### PR TITLE
AP-24 logging

### DIFF
--- a/apollo/handlers/root.py
+++ b/apollo/handlers/root.py
@@ -1,10 +1,14 @@
+import logging
+
 from apollo.lib.router import SecureRouter
 from apollo.lib.schemas.version import VersionSchema
 from apollo.lib.version import version
 
+log = logging.getLogger(__name__)
 router = SecureRouter()
 
 
 @router.get("/", response_model=VersionSchema)
 def get_root():
+    logging.critical('handler')
     return {'version': version}

--- a/apollo/handlers/root.py
+++ b/apollo/handlers/root.py
@@ -1,14 +1,10 @@
-import logging
-
 from apollo.lib.router import SecureRouter
 from apollo.lib.schemas.version import VersionSchema
 from apollo.lib.version import version
 
-log = logging.getLogger(__name__)
 router = SecureRouter()
 
 
 @router.get("/", response_model=VersionSchema)
 def get_root():
-    logging.critical('handler')
     return {'version': version}

--- a/apollo/lib/logging.py
+++ b/apollo/lib/logging.py
@@ -1,7 +1,10 @@
+import logging
 from copy import copy
 
 import click
 from uvicorn.logging import ColourizedFormatter
+
+audit_logger = logging.getLogger('audit')
 
 
 class AuditFormatter(ColourizedFormatter):

--- a/apollo/lib/logging.py
+++ b/apollo/lib/logging.py
@@ -6,11 +6,14 @@ from uvicorn.logging import ColourizedFormatter
 
 audit_logger = logging.getLogger('audit')
 
+GRANTED = 'granted'
+DENIED = 'denied'
+
 
 class AuditFormatter(ColourizedFormatter):
     access_colors = {
-        'granted': 'green',
-        'denied': 'red'
+        GRANTED: 'green',
+        DENIED: 'red'
     }
 
     def format_access(self, access):
@@ -18,12 +21,12 @@ class AuditFormatter(ColourizedFormatter):
                            bold=False)
 
     def format_permission_log(self, record_msg):
-        if 'granted' in record_msg:
-            record_msg = record_msg.replace('granted',
-                                            self.format_access('granted'))
-        elif 'denied' in record_msg:
-            record_msg = record_msg.replace('denied',
-                                            self.format_access('denied'))
+        if GRANTED in record_msg:
+            record_msg = record_msg.replace(GRANTED,
+                                            self.format_access(GRANTED))
+        elif DENIED in record_msg:
+            record_msg = record_msg.replace(DENIED,
+                                            self.format_access(DENIED))
 
         return record_msg
 

--- a/apollo/lib/logging.py
+++ b/apollo/lib/logging.py
@@ -15,8 +15,6 @@ class AuditFormatter(ColourizedFormatter):
                            bold=False)
 
     def format_permission_log(self, record_msg):
-        record_msg = click.style(record_msg, bold=True)
-
         if 'granted' in record_msg:
             record_msg = record_msg.replace('granted',
                                             self.format_access('granted'))
@@ -29,9 +27,11 @@ class AuditFormatter(ColourizedFormatter):
     def formatMessage(self, record):
         record_copy = copy(record)
 
+        styled_message = click.style(record_copy.msg, bold=True)
+
         if 'Permission' in record_copy.msg:
-            record_copy.__dict__['color_message'] = self.format_permission_log(
-                record_copy.msg
-            )
+            styled_message = self.format_permission_log(styled_message)
+
+        record_copy.__dict__['color_message'] = styled_message
 
         return super().formatMessage(record_copy)

--- a/apollo/lib/logging.py
+++ b/apollo/lib/logging.py
@@ -1,5 +1,37 @@
-from unicorn.logging import ColourizedFormatter
+from copy import copy
+
+import click
+from uvicorn.logging import ColourizedFormatter
 
 
-class SecurityFormatter(ColourizedFormatter):
-    pass
+class AuditFormatter(ColourizedFormatter):
+    access_colors = {
+        'granted': 'green',
+        'denied': 'red'
+    }
+
+    def format_access(self, access):
+        return click.style(access.upper(), fg=self.access_colors[access],
+                           bold=False)
+
+    def format_permission_log(self, record_msg):
+        record_msg = click.style(record_msg, bold=True)
+
+        if 'granted' in record_msg:
+            record_msg = record_msg.replace('granted',
+                                            self.format_access('granted'))
+        elif 'denied' in record_msg:
+            record_msg = record_msg.replace('denied',
+                                            self.format_access('denied'))
+
+        return record_msg
+
+    def formatMessage(self, record):
+        record_copy = copy(record)
+
+        if 'Permission' in record_copy.msg:
+            record_copy.__dict__['color_message'] = self.format_permission_log(
+                record_copy.msg
+            )
+
+        return super().formatMessage(record_copy)

--- a/apollo/lib/logging.py
+++ b/apollo/lib/logging.py
@@ -1,0 +1,5 @@
+from unicorn.logging import ColourizedFormatter
+
+
+class SecurityFormatter(ColourizedFormatter):
+    pass

--- a/apollo/lib/security/__init__.py
+++ b/apollo/lib/security/__init__.py
@@ -157,6 +157,11 @@ def parse_authorization_header(authorization: str):
         agent_id, secret = decoded_header.split(':')
     except ValueError:
         raise invalid_header_exception
+
+    log.info(
+        f"Verified OAuth client credentials for agent: {agent_id}"
+    )
+
     return {
         'agent_id': agent_id,
         'secret': secret

--- a/apollo/lib/security/__init__.py
+++ b/apollo/lib/security/__init__.py
@@ -1,5 +1,4 @@
 import base64
-import logging
 
 import jwt
 from sqlalchemy.orm.exc import NoResultFound
@@ -9,11 +8,10 @@ from apollo.lib.exceptions import HTTPException
 from apollo.lib.exceptions.oauth import (
     AuthorizationHeaderNotFound, InvalidAuthorizationMethod,
     InvalidAuthorizationHeader)
+from apollo.lib.logging import audit_logger as log
 from apollo.lib.settings import settings
 from apollo.models.oauth import get_access_token_by_token
 from apollo.models.user import get_user_by_id
-
-log = logging.getLogger('audit')
 
 Authenticated = 'Authenticated'
 Allow = 'Allow'

--- a/apollo/lib/security/__init__.py
+++ b/apollo/lib/security/__init__.py
@@ -13,7 +13,7 @@ from apollo.lib.settings import settings
 from apollo.models.oauth import get_access_token_by_token
 from apollo.models.user import get_user_by_id
 
-log = logging.getLogger('security')
+log = logging.getLogger('audit')
 
 Authenticated = 'Authenticated'
 Allow = 'Allow'

--- a/apollo/lib/security/__init__.py
+++ b/apollo/lib/security/__init__.py
@@ -13,7 +13,7 @@ from apollo.lib.settings import settings
 from apollo.models.oauth import get_access_token_by_token
 from apollo.models.user import get_user_by_id
 
-log = logging.getLogger(__name__)
+log = logging.getLogger('security')
 
 Authenticated = 'Authenticated'
 Allow = 'Allow'
@@ -47,6 +47,8 @@ class AuthorizationPolicy:
             if authenticated_user.role:
                 principals.append(f"role:{authenticated_user.role.name}")
 
+        log.debug(f"Found principals: {principals}")
+
         return principals
 
     @staticmethod
@@ -66,6 +68,9 @@ class AuthorizationPolicy:
         if not access_token.client.active or access_token.expired:
             return
 
+        log.info(
+            f"Authenticated access token for agent: {access_token.client_id}"
+        )
         return access_token
 
     @staticmethod
@@ -79,14 +84,20 @@ class AuthorizationPolicy:
         except KeyError:
             return None
 
-        return get_user_by_id(session, payload['authenticated_user_id'])
+        auth_user_id = payload['authenticated_user_id']
+        log.info(f"Authenticated user: {auth_user_id}")
+
+        return get_user_by_id(session, auth_user_id)
 
     def get_complete_acl(self, context_acl_provider=None):
         acl = self.acl_provider.__acl__()
         if not context_acl_provider:
             return acl
 
-        return context_acl_provider.__acl__() + acl
+        complete_acl = context_acl_provider.__acl__() + acl
+        log.debug(f"complete ACL: {complete_acl}")
+
+        return complete_acl
 
     def check_permission(self, requested_permission,
                          http_connection, context_acl_provider=None):
@@ -100,8 +111,10 @@ class AuthorizationPolicy:
                 continue
 
             if action is Allow:
+                log.info(f"Permission '{permission}' granted")
                 return True
             elif action is Deny:
+                log.info(f"Permission '{permission}' denied")
                 return False
             else:
                 raise ValueError("Invalid action in ACL")

--- a/dev-compose.yml
+++ b/dev-compose.yml
@@ -20,7 +20,7 @@ services:
     command: >
       -c "../util/wait-for-it.sh db:5432 &&
       alembic -c local-settings.ini upgrade heads &&
-      uvicorn apollo:main --reload --host 0.0.0.0"
+      uvicorn apollo:main --log-config local-settings.ini --reload --host 0.0.0.0"
   db:
     container_name: apollo-db
     image: postgres:12

--- a/local-settings.ini.dist
+++ b/local-settings.ini.dist
@@ -98,7 +98,7 @@ class = uvicorn.logging.DefaultFormatter
 
 [formatter_audit]
 format = %(levelprefix)s %(asctime)s %(message)s
-class = apollo.lib.logging.SecurityFormatter
+class = apollo.lib.logging.AuditFormatter
 
 [formatter_access]
 format = %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s

--- a/local-settings.ini.dist
+++ b/local-settings.ini.dist
@@ -11,17 +11,17 @@ sqlalchemy.url = postgres://<username>:<password>@<host>:5432/apollo
 
 # Logging configuration
 [loggers]
-keys = root,sqlalchemy,alembic
+keys = root, sqlalchemy, uvicorn, uvicorn.error, uvicorn.access, alembic
 
 [handlers]
-keys = console
+keys = default, simple, access
 
 [formatters]
-keys = generic
+keys = default, simple, access
 
 [logger_root]
 level = WARN
-handlers = console
+handlers = default
 qualname =
 
 [logger_sqlalchemy]
@@ -29,17 +29,54 @@ level = WARN
 handlers =
 qualname = sqlalchemy.engine
 
+[logger_uvicorn]
+level = INFO
+handlers = simple
+qualname = uvicorn
+propagate=0
+
+[logger_uvicorn.error]
+level = INFO
+handlers =
+qualname = uvicorn.error
+
+[logger_uvicorn.access]
+level = INFO
+handlers = simple
+qualname = uvicorn.access
+propagate=0
+
 [logger_alembic]
 level = INFO
 handlers =
 qualname = alembic
 
-[handler_console]
+[handler_default]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
-formatter = generic
+formatter = default
 
-[formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
+[handler_simple]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = simple
+
+[handler_access]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = access
+
+[formatter_default]
+format = %(levelname)-5.5s %(asctime)s [%(name)s:%(lineno)s] %(message)s
 datefmt = %H:%M:%S
+
+[formatter_simple]
+format = %(levelprefix)s %(message)s
+class = uvicorn.logging.DefaultFormatter
+
+[formatter_access]
+format = "%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s"
+class = uvicorn.logging.AccessFormatter

--- a/local-settings.ini.dist
+++ b/local-settings.ini.dist
@@ -11,23 +11,23 @@ sqlalchemy.url = postgres://<username>:<password>@<host>:5432/apollo
 
 # Logging configuration
 [loggers]
-keys = root, security, sqlalchemy, uvicorn, uvicorn.error, uvicorn.access, alembic
+keys = root, audit, sqlalchemy, uvicorn, uvicorn.error, uvicorn.access, alembic
 
 [handlers]
-keys = simple, error, access, security, uvicorn
+keys = simple, error, access, audit, uvicorn
 
 [formatters]
-keys = simple, verbose, access, security
+keys = simple, verbose, access, audit
 
 [logger_root]
 level = WARN
 handlers = simple, error
 qualname =
 
-[logger_security]
+[logger_audit]
 level = INFO
-handlers = security, error
-qualname = security
+handlers = audit, error
+qualname = audit
 propagate=0
 
 [logger_sqlalchemy]
@@ -69,11 +69,11 @@ args = (sys.stderr,)
 level = ERROR
 formatter = verbose
 
-[handler_security]
+[handler_audit]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
-formatter = security
+formatter = audit
 
 [handler_uvicorn]
 class = StreamHandler
@@ -96,7 +96,7 @@ format = %(levelprefix)s %(asctime)s [%(pathname)s:%(lineno)s] %(message)s
 datefmt = %H:%M:%S
 class = uvicorn.logging.DefaultFormatter
 
-[formatter_security]
+[formatter_audit]
 format = %(levelprefix)s %(asctime)s %(message)s
 class = apollo.lib.logging.SecurityFormatter
 

--- a/local-settings.ini.dist
+++ b/local-settings.ini.dist
@@ -11,18 +11,24 @@ sqlalchemy.url = postgres://<username>:<password>@<host>:5432/apollo
 
 # Logging configuration
 [loggers]
-keys = root, sqlalchemy, uvicorn, uvicorn.error, uvicorn.access, alembic
+keys = root, security, sqlalchemy, uvicorn, uvicorn.error, uvicorn.access, alembic
 
 [handlers]
-keys = default, simple, access
+keys = simple, error, access, security, uvicorn
 
 [formatters]
-keys = default, simple, access
+keys = simple, verbose, access, security
 
 [logger_root]
 level = WARN
-handlers = default
+handlers = simple, error
 qualname =
+
+[logger_security]
+level = INFO
+handlers = security, error
+qualname = security
+propagate=0
 
 [logger_sqlalchemy]
 level = WARN
@@ -31,7 +37,7 @@ qualname = sqlalchemy.engine
 
 [logger_uvicorn]
 level = INFO
-handlers = simple
+handlers = uvicorn
 qualname = uvicorn
 propagate=0
 
@@ -42,7 +48,7 @@ qualname = uvicorn.error
 
 [logger_uvicorn.access]
 level = INFO
-handlers = simple
+handlers = access
 qualname = uvicorn.access
 propagate=0
 
@@ -51,13 +57,25 @@ level = INFO
 handlers =
 qualname = alembic
 
-[handler_default]
+[handler_simple]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
-formatter = default
+formatter = simple
 
-[handler_simple]
+[handler_error]
+class = StreamHandler
+args = (sys.stderr,)
+level = ERROR
+formatter = verbose
+
+[handler_security]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = security
+
+[handler_uvicorn]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
@@ -69,14 +87,19 @@ args = (sys.stderr,)
 level = NOTSET
 formatter = access
 
-[formatter_default]
-format = %(levelname)-5.5s %(asctime)s [%(name)s:%(lineno)s] %(message)s
-datefmt = %H:%M:%S
-
 [formatter_simple]
 format = %(levelprefix)s %(message)s
 class = uvicorn.logging.DefaultFormatter
 
+[formatter_verbose]
+format = %(levelprefix)s %(asctime)s [%(pathname)s:%(lineno)s] %(message)s
+datefmt = %H:%M:%S
+class = uvicorn.logging.DefaultFormatter
+
+[formatter_security]
+format = %(levelprefix)s %(asctime)s %(message)s
+class = uvicorn.logging.DefaultFormatter
+
 [formatter_access]
-format = "%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s"
+format = %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s
 class = uvicorn.logging.AccessFormatter

--- a/local-settings.ini.dist
+++ b/local-settings.ini.dist
@@ -98,7 +98,7 @@ class = uvicorn.logging.DefaultFormatter
 
 [formatter_security]
 format = %(levelprefix)s %(asctime)s %(message)s
-class = uvicorn.logging.DefaultFormatter
+class = apollo.lib.logging.SecurityFormatter
 
 [formatter_access]
 format = %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ requires = [
     'psycopg2',
     'pydantic',
     'pyjwt',
-    'sqlalchemy'
+    'sqlalchemy',
+    'uvicorn'
 ]
 
 test_requires = [
@@ -24,8 +25,7 @@ test_requires = [
 ]
 
 dev_requires = [
-    'alembic',
-    'uvicorn'
+    'alembic'
 ]
 
 extras = {

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open(os.path.join(here, 'VERSION')) as f:
 
 requires = [
     'bcrypt',
+    'click',
     'fastapi',
     'psycopg2',
     'pydantic',

--- a/tests/lib/test_logging.py
+++ b/tests/lib/test_logging.py
@@ -1,20 +1,54 @@
 import click
 import pytest
+from logging import LogRecord, INFO
 
 from apollo.lib.logging import AuditFormatter
 
+GRANTED = click.style('GRANTED', fg='green', bold=False)
+DENIED = click.style('DENIED', fg='red', bold=False)
+
+FAKE_GRANT = "Permission 'fake' granted"
+FAKE_DENIED = "Permission 'fake' denied"
+LOREM = "Lorem ipsum"
+
+FAKE_GRANT_STYLED = click.style(FAKE_GRANT, bold=True).replace(
+    'granted', GRANTED)
+FAKE_DENIED_STYLED = click.style(FAKE_DENIED, bold=True).replace(
+    'denied', DENIED)
+LOREM_STYLED = click.style(LOREM, bold=True)
+
 
 @pytest.mark.parametrize("access,expected", (
-    ('granted', click.style('GRANTED', fg='green', bold=False)),
-    ('denied', click.style('DENIED', fg='red', bold=False))
+    ('granted', GRANTED),
+    ('denied', DENIED)
 ))
 def test_audit_formatter_format_access(access, expected):
     assert AuditFormatter().format_access(access) == expected
 
 
-def test_audit_formatter_format_permission_log():
-    pass
+@pytest.mark.parametrize("msg,expected", (
+    (FAKE_GRANT, FAKE_GRANT.replace('granted', GRANTED)),
+    (FAKE_DENIED, FAKE_DENIED.replace('denied', DENIED)),
+    (LOREM, LOREM)
+))
+def test_audit_formatter_format_permission_log(msg, expected):
+    assert AuditFormatter().format_permission_log(msg) == expected
 
 
-def test_audit_formatter_format_message():
-    pass
+@pytest.mark.parametrize("msg,expected", (
+    (FAKE_GRANT, FAKE_GRANT_STYLED),
+    (FAKE_DENIED, FAKE_DENIED_STYLED),
+    (LOREM, LOREM_STYLED)
+))
+def test_audit_formatter_format_message(msg, expected):
+    record = LogRecord(
+        name='fake',
+        level=INFO,
+        pathname='/fake.py',
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None
+    )
+    record.__dict__['message'] = record.msg
+    assert AuditFormatter(use_colors=True).formatMessage(record) == expected

--- a/tests/lib/test_logging.py
+++ b/tests/lib/test_logging.py
@@ -1,0 +1,20 @@
+import click
+import pytest
+
+from apollo.lib.logging import AuditFormatter
+
+
+@pytest.mark.parametrize("access,expected", (
+    ('granted', click.style('GRANTED', fg='green', bold=False)),
+    ('denied', click.style('DENIED', fg='red', bold=False))
+))
+def test_audit_formatter_format_access(access, expected):
+    assert AuditFormatter().format_access(access) == expected
+
+
+def test_audit_formatter_format_permission_log():
+    pass
+
+
+def test_audit_formatter_format_message():
+    pass


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-24>

## Description
Includes configuration for various loggers, handlers and formatters.

Also includes a start on a logger meant for audit. There's some basic permission logging but the rest is out of scope since we want to guarantee more metadata. What is currently there is also meant to serve as an example.


The `AuditFormatter` extends the formatter of Uvicorn for now to prevent duplication.

Depending on the level the loggers will also log in a more verbose format.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

*

## Additional notes
Unless you're doing audit logging you can just log on the `logging` module. Otherwise you can get the logger using `audit_logger`.
