### PR TITLE
AP-36 agent compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.8
 
+ENV PATH="${PATH}:/usr/local/go/bin"
+
 RUN addgroup apollo
 RUN useradd -g apollo apollo
 
@@ -7,6 +9,11 @@ COPY . /home/apollo/apollo
 WORKDIR /home/apollo
 
 RUN pip install -e apollo[dev,tests]
+
+# Install Go to allow Apollo to compile the agent
+RUN wget https://golang.org/dl/go1.14.4.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.14.4.linux-amd64.tar.gz
+RUN rm go1.14.4.linux-amd64.tar.gz
 
 # Download wait-for-it to allow waiting for dependency containers
 RUN mkdir util

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.8
 
+ARG go_version=1.14.4
+
 ENV PATH="${PATH}:/usr/local/go/bin"
+ENV GO_VERSION=$go_version
 
 RUN addgroup apollo
 RUN useradd -g apollo apollo
@@ -11,9 +14,9 @@ WORKDIR /home/apollo
 RUN pip install -e apollo[dev,tests]
 
 # Install Go to allow Apollo to compile the agent
-RUN wget https://golang.org/dl/go1.14.4.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.14.4.linux-amd64.tar.gz
-RUN rm go1.14.4.linux-amd64.tar.gz
+RUN wget https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+RUN rm go${GO_VERSION}.linux-amd64.tar.gz
 
 # Download wait-for-it to allow waiting for dependency containers
 RUN mkdir util

--- a/apollo/handlers/agent.py
+++ b/apollo/handlers/agent.py
@@ -1,5 +1,3 @@
-import os
-import subprocess
 import uuid
 from typing import List
 
@@ -7,6 +5,7 @@ from fastapi import Depends, WebSocket
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
+from apollo.lib.agent import AgentBinary
 from apollo.lib.router import SecureRouter
 from apollo.lib.schemas.agent import (
     AgentSchema, BaseAgentSchema, CreateAgentSchema)
@@ -43,17 +42,7 @@ def list_agents(session: Session = Depends(get_session)):
 
 @router.get('/agent/download', status_code=200, permission='agent.download')
 async def download_agent():
-    # Always make sure to get the latest version
-    binary_path = f"/tmp/{uuid.uuid4()}"
-    subprocess.run(["go", "get", "-d", "-u",
-                    "github.com/thecoderstudio/apollo-agent"])
-
-    env = os.environ.copy()
-    env["GOOS"] = "darwin"
-    env["GOARCH"] = "amd64"
-    subprocess.run(["go", "build", "-o", binary_path,
-                    "github.com/thecoderstudio/apollo-agent"], env=env)
-    return FileResponse(binary_path)
+    return FileResponse(AgentBinary("darwin", "amd64").path)
 
 
 @router.websocket("/agent/{agent_id}/shell", permission='agent.shell')

--- a/apollo/handlers/agent.py
+++ b/apollo/handlers/agent.py
@@ -42,7 +42,7 @@ def list_agents(session: Session = Depends(get_session)):
 
 @router.get('/agent/download', status_code=200, permission='agent.download')
 async def download_agent(binary: AgentBinary = Depends(create_agent_binary)):
-    return FileResponse(binary.path)
+    return FileResponse(binary.path, filename='apollo-agent')
 
 
 @router.websocket("/agent/{agent_id}/shell", permission='agent.shell')

--- a/apollo/handlers/agent.py
+++ b/apollo/handlers/agent.py
@@ -5,7 +5,7 @@ from fastapi import Depends, WebSocket
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
-from apollo.lib.agent import AgentBinary
+from apollo.lib.agent import AgentBinary, create_agent_binary
 from apollo.lib.router import SecureRouter
 from apollo.lib.schemas.agent import (
     AgentSchema, BaseAgentSchema, CreateAgentSchema)
@@ -41,8 +41,8 @@ def list_agents(session: Session = Depends(get_session)):
 
 
 @router.get('/agent/download', status_code=200, permission='agent.download')
-async def download_agent():
-    return FileResponse(AgentBinary("darwin", "amd64").path)
+async def download_agent(binary: AgentBinary = Depends(create_agent_binary)):
+    return FileResponse(binary.path)
 
 
 @router.websocket("/agent/{agent_id}/shell", permission='agent.shell')

--- a/apollo/handlers/agent.py
+++ b/apollo/handlers/agent.py
@@ -1,13 +1,16 @@
+import os
+import subprocess
 import uuid
 from typing import List
 
 from fastapi import Depends, WebSocket
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
 from apollo.lib.router import SecureRouter
 from apollo.lib.schemas.agent import (
     AgentSchema, BaseAgentSchema, CreateAgentSchema)
-from apollo.lib.security import Allow, Authenticated
+from apollo.lib.security import Allow, Authenticated, Everyone
 from apollo.lib.websocket.user import UserConnectionManager
 from apollo.models import get_session, save
 from apollo.models.agent import Agent, list_all_agents
@@ -16,6 +19,7 @@ from apollo.models.oauth import OAuthClient
 router = SecureRouter([
     (Allow, Authenticated, 'agent.post'),
     (Allow, Authenticated, 'agent.list'),
+    (Allow, Everyone, 'agent.download'),
     (Allow, Authenticated, 'agent.shell')
 ])
 
@@ -35,6 +39,21 @@ def post_agent(agent_data: CreateAgentSchema,
             permission='agent.list')
 def list_agents(session: Session = Depends(get_session)):
     return list_all_agents(session)
+
+
+@router.get('/agent/download', status_code=200, permission='agent.download')
+async def download_agent():
+    # Always make sure to get the latest version
+    binary_path = f"/tmp/{uuid.uuid4()}"
+    subprocess.run(["go", "get", "-d", "-u",
+                    "github.com/thecoderstudio/apollo-agent"])
+
+    env = os.environ.copy()
+    env["GOOS"] = "darwin"
+    env["GOARCH"] = "amd64"
+    subprocess.run(["go", "build", "-o", binary_path,
+                    "github.com/thecoderstudio/apollo-agent"], env=env)
+    return FileResponse(binary_path)
 
 
 @router.websocket("/agent/{agent_id}/shell", permission='agent.shell')

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -44,5 +44,7 @@ class AgentBinary:
 
 def create_agent_binary(target_os: SupportedOS, target_arch: SupportedArch):
     binary = AgentBinary(target_os, target_arch)
-    yield binary
-    binary.delete()
+    try:
+        yield binary
+    finally:
+        binary.delete()

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -9,6 +9,7 @@ PACKAGE = 'github.com/thecoderstudio/apollo-agent'
 class SupportedOS(Enum):
     DARWIN = 'darwin'
     LINUX = 'linux'
+    FREEBSD = 'freebsd'
 
 
 class SupportedArch(Enum):

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+import uuid
+from enum import Enum
+
+PACKAGE = "github.com/thecoderstudio/apollo-agent"
+
+
+class SupportedOS(Enum):
+    DARWIN = "darwin"
+
+
+class SupportedArch(Enum):
+    AMD_64 = "amd64"
+
+
+class AgentBinary:
+    def __init__(self, target_os: SupportedOS, target_arch: SupportedArch):
+        self.path = f"/tmp/{uuid.uuid4()}"
+        self.target_os = target_os
+        self.target_arch = target_arch
+
+        # Always make sure to get the latest version
+        self._download_source()
+
+        self._compile()
+
+    @staticmethod
+    def _download_source():
+        subprocess.run(["go", "get", "-d", "-u", PACKAGE])
+
+    def _compile(self):
+        env = os.environ.copy()
+        env["GOOS"] = self.target_os
+        env["GOARCH"] = self.target_arch
+        subprocess.run(["go", "build", "-o", self.path, PACKAGE], env=env)
+
+    def delete(self):
+        os.remove(self.path)

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -8,10 +8,13 @@ PACKAGE = "github.com/thecoderstudio/apollo-agent"
 
 class SupportedOS(Enum):
     DARWIN = "darwin"
+    LINUX = "linux"
 
 
 class SupportedArch(Enum):
     AMD_64 = "amd64"
+    ARM_64 = "arm64"
+    ARM = "arm"
 
 
 class AgentBinary:

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -31,9 +31,19 @@ class AgentBinary:
 
     def _compile(self):
         env = os.environ.copy()
-        env["GOOS"] = self.target_os
-        env["GOARCH"] = self.target_arch
+        env["GOOS"] = self.target_os.value
+        env["GOARCH"] = self.target_arch.value
         subprocess.run(["go", "build", "-o", self.path, PACKAGE], env=env)
 
     def delete(self):
         os.remove(self.path)
+
+
+# Prevent circular import
+from apollo.lib.schemas.agent import AgentBinarySchema  # noqa
+
+
+def create_agent_binary(data: AgentBinarySchema):
+    binary = AgentBinary(**data.dict())
+    yield binary
+    binary.delete()

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 import uuid
@@ -49,4 +50,8 @@ def create_agent_binary(target_os: SupportedOS, target_arch: SupportedArch):
     try:
         yield binary
     finally:
-        binary.delete()
+        try:
+            binary.delete()
+        except FileNotFoundError as e:
+            logging.debug(str(e))
+            pass

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -4,6 +4,8 @@ import subprocess
 import uuid
 from enum import Enum
 
+from apollo.lib.settings import settings
+
 PACKAGE = 'github.com/thecoderstudio/apollo-agent'
 
 
@@ -22,6 +24,7 @@ class SupportedArch(Enum):
 
 class AgentBinary:
     def __init__(self, target_os: SupportedOS, target_arch: SupportedArch):
+        self.go = settings['agent']['go_path']
         self.path = f"/tmp/{uuid.uuid4()}"
         self.target_os = target_os
         self.target_arch = target_arch
@@ -31,15 +34,14 @@ class AgentBinary:
 
         self._compile()
 
-    @staticmethod
-    def _download_source():
-        subprocess.run(['go', 'get', '-d', '-u', PACKAGE])
+    def _download_source(self):
+        subprocess.run([self.go, 'get', '-d', '-u', PACKAGE])
 
     def _compile(self):
         env = os.environ.copy()
         env['GOOS'] = self.target_os.value
         env['GOARCH'] = self.target_arch.value
-        subprocess.run(['go', 'build', '-o', self.path, PACKAGE], env=env)
+        subprocess.run([self.go, 'build', '-o', self.path, PACKAGE], env=env)
 
     def delete(self):
         try:

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -3,18 +3,18 @@ import subprocess
 import uuid
 from enum import Enum
 
-PACKAGE = "github.com/thecoderstudio/apollo-agent"
+PACKAGE = 'github.com/thecoderstudio/apollo-agent'
 
 
 class SupportedOS(Enum):
-    DARWIN = "darwin"
-    LINUX = "linux"
+    DARWIN = 'darwin'
+    LINUX = 'linux'
 
 
 class SupportedArch(Enum):
-    AMD_64 = "amd64"
-    ARM_64 = "arm64"
-    ARM = "arm"
+    AMD_64 = 'amd64'
+    ARM_64 = 'arm64'
+    ARM = 'arm'
 
 
 class AgentBinary:
@@ -30,13 +30,13 @@ class AgentBinary:
 
     @staticmethod
     def _download_source():
-        subprocess.run(["go", "get", "-d", "-u", PACKAGE])
+        subprocess.run(['go', 'get', '-d', '-u', PACKAGE])
 
     def _compile(self):
         env = os.environ.copy()
-        env["GOOS"] = self.target_os.value
-        env["GOARCH"] = self.target_arch.value
-        subprocess.run(["go", "build", "-o", self.path, PACKAGE], env=env)
+        env['GOOS'] = self.target_os.value
+        env['GOARCH'] = self.target_arch.value
+        subprocess.run(['go', 'build', '-o', self.path, PACKAGE], env=env)
 
     def delete(self):
         os.remove(self.path)

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -42,11 +42,7 @@ class AgentBinary:
         os.remove(self.path)
 
 
-# Prevent circular import
-from apollo.lib.schemas.agent import AgentBinarySchema  # noqa
-
-
-def create_agent_binary(data: AgentBinarySchema):
-    binary = AgentBinary(**data.dict())
+def create_agent_binary(target_os: SupportedOS, target_arch: SupportedArch):
+    binary = AgentBinary(target_os, target_arch)
     yield binary
     binary.delete()

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -42,7 +42,10 @@ class AgentBinary:
         subprocess.run(['go', 'build', '-o', self.path, PACKAGE], env=env)
 
     def delete(self):
-        os.remove(self.path)
+        try:
+            os.remove(self.path)
+        except FileNotFoundError as e:
+            logging.debug(str(e))
 
 
 def create_agent_binary(target_os: SupportedOS, target_arch: SupportedArch):
@@ -50,8 +53,4 @@ def create_agent_binary(target_os: SupportedOS, target_arch: SupportedArch):
     try:
         yield binary
     finally:
-        try:
-            binary.delete()
-        except FileNotFoundError as e:
-            logging.debug(str(e))
-            pass
+        binary.delete()

--- a/apollo/lib/agent.py
+++ b/apollo/lib/agent.py
@@ -10,6 +10,7 @@ class SupportedOS(Enum):
     DARWIN = 'darwin'
     LINUX = 'linux'
     FREEBSD = 'freebsd'
+    OPENBSD = 'openbsd'
 
 
 class SupportedArch(Enum):

--- a/apollo/lib/router.py
+++ b/apollo/lib/router.py
@@ -64,9 +64,13 @@ class SecureRouter(APIRouter):
         route = getattr(super(SecureRouter, self), http_method)
 
         @route(*outer_args, **outer_kwargs)
-        def wrapped(request: Request, *args, **kwargs):
+        async def wrapped(request: Request, *args, **kwargs):
             self.acl_policy.validate_permission(permission, request)
-            return func(*args, **kwargs)
+            output = func(*args, **kwargs)
+            if inspect.iscoroutine(output):
+                output = await output
+
+            return output
 
         wrapped_signature = inspect.signature(wrapped)
         func_signature = inspect.signature(func)

--- a/apollo/lib/schemas/agent.py
+++ b/apollo/lib/schemas/agent.py
@@ -3,7 +3,6 @@ import uuid
 from pydantic import BaseModel, constr, validator
 from starlette.websockets import WebSocketState
 
-from apollo.lib.agent import SupportedArch, SupportedOS
 from apollo.lib.decorators import with_db_session
 from apollo.lib.schemas import ORMBase
 from apollo.lib.schemas.oauth import OAuthClientSchema
@@ -37,8 +36,3 @@ class BaseAgentSchema(ORMBase):
 
 class AgentSchema(BaseAgentSchema):
     oauth_client: OAuthClientSchema
-
-
-class AgentBinarySchema(BaseModel):
-    target_os: SupportedOS
-    target_arch: SupportedArch

--- a/apollo/lib/schemas/agent.py
+++ b/apollo/lib/schemas/agent.py
@@ -3,6 +3,7 @@ import uuid
 from pydantic import BaseModel, constr, validator
 from starlette.websockets import WebSocketState
 
+from apollo.lib.agent import SupportedArch, SupportedOS
 from apollo.lib.decorators import with_db_session
 from apollo.lib.schemas import ORMBase
 from apollo.lib.schemas.oauth import OAuthClientSchema
@@ -36,3 +37,8 @@ class BaseAgentSchema(ORMBase):
 
 class AgentSchema(BaseAgentSchema):
     oauth_client: OAuthClientSchema
+
+
+class AgentBinarySchema(BaseModel):
+    target_os: SupportedOS
+    target_arch: SupportedArch

--- a/local-settings.ini.dist
+++ b/local-settings.ini.dist
@@ -5,6 +5,10 @@ password =
 [session]
 secret =
 
+[agent]
+# Location in Docker container
+go_path = /usr/local/go/bin/go
+
 [alembic]
 script_location = alembic
 sqlalchemy.url = postgres://<username>:<password>@<host>:5432/apollo

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ with open(os.path.join(here, 'VERSION')) as f:
     version = f.read().strip()
 
 requires = [
+    'aiofiles',
     'bcrypt',
     'click',
     'fastapi',

--- a/test.ini
+++ b/test.ini
@@ -9,6 +9,9 @@ password = testing123
 # Don't reuse, only for test
 secret = 03aa24c04d80ee5e4e17bf62db461e3b2b5777091c7f28072947f8b81e7a2958 
 
+[agent]
+go_path = /usr/local/go/bin/go
+
 [alembic]
 script_location = alembic
 sqlalchemy.url = postgres://apollo:testing123@db-test:5432/apollo-test

--- a/tests/handlers/test_agent.py
+++ b/tests/handlers/test_agent.py
@@ -44,6 +44,15 @@ def test_post_agent_unauthenticated(test_client, db_session):
     assert response.json()['detail'] == "Permission denied."
 
 
+def test_download_agent(test_client):
+    response = test_client.get(
+        '/agent/download?target_os=darwin&target_arch=amd64')
+    assert response.status_code == 200
+    assert response.headers['Content-Disposition'] == (
+        'attachment; filename="apollo-agent"')
+    assert response.text is not None
+
+
 @pytest.mark.asyncio
 async def test_shell(mocker, test_client, session_cookie, websocket_manager):
     connection_id = uuid.uuid4()

--- a/tests/lib/test_agent.py
+++ b/tests/lib/test_agent.py
@@ -2,16 +2,12 @@ import os
 
 from apollo.lib.agent import (AgentBinary, SupportedArch, SupportedOS,
                               create_agent_binary)
-from apollo.lib.schemas.agent import AgentBinarySchema
 
 
 def test_create_agent_binary():
     path: str
 
-    for binary in create_agent_binary(AgentBinarySchema(
-        target_os='linux',
-        target_arch='amd64'
-    )):
+    for binary in create_agent_binary(SupportedOS.LINUX, SupportedArch.AMD_64):
         assert binary.target_os == SupportedOS.LINUX
         assert binary.target_arch == SupportedArch.AMD_64
         path = binary.path

--- a/tests/lib/test_agent.py
+++ b/tests/lib/test_agent.py
@@ -1,0 +1,28 @@
+import os
+
+from apollo.lib.agent import (AgentBinary, SupportedArch, SupportedOS,
+                              create_agent_binary)
+from apollo.lib.schemas.agent import AgentBinarySchema
+
+
+def test_create_agent_binary():
+    path: str
+
+    for binary in create_agent_binary(AgentBinarySchema(
+        target_os='linux',
+        target_arch='amd64'
+    )):
+        assert binary.target_os == SupportedOS.LINUX
+        assert binary.target_arch == SupportedArch.AMD_64
+        path = binary.path
+        assert os.path.isfile(path)
+
+    # Assert binary gets deleted
+    binary = None
+    assert not os.path.isfile(path)
+
+
+def test_delete_agent_binary():
+    binary = AgentBinary(SupportedOS.LINUX, SupportedArch.AMD_64)
+    binary.delete()
+    assert not os.path.isfile(binary.path)

--- a/tests/lib/test_agent.py
+++ b/tests/lib/test_agent.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 from apollo.lib.agent import (AgentBinary, SupportedArch, SupportedOS,
                               create_agent_binary)
@@ -22,3 +23,10 @@ def test_delete_agent_binary():
     binary = AgentBinary(SupportedOS.LINUX, SupportedArch.AMD_64)
     binary.delete()
     assert not os.path.isfile(binary.path)
+
+
+def test_delete_agent_binary_file_not_exist():
+    with patch('apollo.lib.agent.AgentBinary._compile'):
+        binary = AgentBinary(SupportedOS.LINUX, SupportedArch.AMD_64)
+        assert not os.path.isfile(binary.path)
+        binary.delete()

--- a/tests/lib/test_router.py
+++ b/tests/lib/test_router.py
@@ -66,7 +66,8 @@ def test_secure_router_additional_acl():
 @pytest.mark.parametrize("permission,auth_header,permitted",
                          oauth_permission_expectations)
 @pytest.mark.parametrize('http_method', testable_http_methods)
-def test_secure_router_http_methods_oauth_permissions(
+@pytest.mark.asyncio
+async def test_secure_router_http_methods_oauth_permissions(
     db_session, access_token, permission, auth_header, permitted, http_method
 ):
     access_token.access_token = (
@@ -84,16 +85,16 @@ def test_secure_router_http_methods_oauth_permissions(
     })
 
     if permitted:
-        call_http_method_decorated_mock(http_method, router_acl, permission,
-                                        request_mock)
+        await call_http_method_decorated_mock(http_method, router_acl,
+                                              permission, request_mock)
     else:
         with raisesHTTPForbidden:
-            call_http_method_decorated_mock(http_method, router_acl,
-                                            permission, request_mock)
+            await call_http_method_decorated_mock(http_method, router_acl,
+                                                  permission, request_mock)
 
 
-def call_http_method_decorated_mock(http_method, router_acl, permission,
-                                    request_mock):
+async def call_http_method_decorated_mock(http_method, router_acl, permission,
+                                          request_mock):
     router = SecureRouter(router_acl)
     route_decorator = getattr(router, http_method)
 
@@ -101,13 +102,14 @@ def call_http_method_decorated_mock(http_method, router_acl, permission,
     def endpoint_mock():
         pass
 
-    endpoint_mock(request=request_mock)
+    await endpoint_mock(request=request_mock)
 
 
 @pytest.mark.parametrize("permission,authenticated,role,permitted",
                          cookie_permission_expectations)
 @pytest.mark.parametrize('http_method', testable_http_methods)
-def test_secure_router_http_methods_cookie_permissions(
+@pytest.mark.asyncio
+async def test_secure_router_http_methods_cookie_permissions(
     db_session, user, session_cookie, permission, authenticated, role,
     permitted, http_method
 ):
@@ -115,12 +117,12 @@ def test_secure_router_http_methods_cookie_permissions(
         db_session, user, authenticated, session_cookie, role)
 
     if permitted:
-        call_http_method_decorated_mock(http_method, router_acl, permission,
-                                        request_mock)
+        await call_http_method_decorated_mock(http_method, router_acl,
+                                              permission, request_mock)
     else:
         with raisesHTTPForbidden:
-            call_http_method_decorated_mock(http_method, router_acl,
-                                            permission, request_mock)
+            await call_http_method_decorated_mock(http_method, router_acl,
+                                                  permission, request_mock)
 
 
 def generate_http_test_parameters(db_session, user, authenticated,

--- a/tests/lib/test_router.py
+++ b/tests/lib/test_router.py
@@ -102,7 +102,12 @@ async def call_http_method_decorated_mock(http_method, router_acl, permission,
     def endpoint_mock():
         pass
 
+    @route_decorator('/test_async', permission=permission)
+    async def async_endpoint_mock():
+        pass
+
     await endpoint_mock(request=request_mock)
+    await async_endpoint_mock(request=request_mock)
 
 
 @pytest.mark.parametrize("permission,authenticated,role,permitted",


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-36>
contains:
<https://partypeak.atlassian.net/browse/AP-38>

## Description
Allows you to call `/agent/download` to get a binary of the Apollo Agent. You need to specify your target OS and architecture. Example:
```
GET https://localhost:1970/apollo/download?target_os=darwin&target_arch=amd64
```

This will compile the binary for the given target and return it for download. Afterward the file will be deleted.

I merged `AP-38` which I used to test out of the box compatibility with the current agent. It was done before this was looked at so I decided to merge it in since it just contained an expansion of the supported OS enum.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

*

## Additional notes
Currently we don't mock the usage of the filesystem and Go. We're already tied to Docker (or at least external dependencies) for testing due to the database interaction. If it performs poorly in the CI or for whatever other reason we can decide to mock the interaction.
