### PR TITLE
Ap 59 agent IP and OS

### DIFF
--- a/alembic/versions/cf61bf3bc2d3_agent_platform_info.py
+++ b/alembic/versions/cf61bf3bc2d3_agent_platform_info.py
@@ -1,0 +1,54 @@
+"""agent platform info
+
+Revision ID: cf61bf3bc2d3
+Revises: 12a9aec438b3
+Create Date: 2020-09-11 07:50:25.638337
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from apollo.lib.agent import SupportedArch, SupportedOS
+
+
+# revision identifiers, used by Alembic.
+revision = 'cf61bf3bc2d3'
+down_revision = '12a9aec438b3'
+branch_labels = None
+depends_on = None
+
+supported_os = postgresql.ENUM(*[member.value for member in SupportedOS],
+                               name='supported_os')
+supported_arch = postgresql.ENUM(*[member.value for member in SupportedArch],
+                                 name='supported_arch')
+
+
+def upgrade():
+    try:
+        supported_os.create(op.get_bind())
+        supported_arch.create(op.get_bind())
+    except AttributeError:
+        pass
+
+    op.add_column('agent', sa.Column('external_ip_address', sa.String(16),
+                                     nullable=True))
+    op.add_column('agent', sa.Column(
+        'operating_system',
+        sa.Enum(SupportedOS, name='supported_os'),
+        nullable=True
+    ))
+    op.add_column('agent', sa.Column(
+        'architecture',
+        sa.Enum(SupportedArch, name='supported_arch'),
+        nullable=True
+    ))
+
+
+def downgrade():
+    op.drop_column('agent', 'external_ip_address')
+    op.drop_column('agent', 'operating_system')
+    op.drop_column('agent', 'architecture')
+
+    supported_os.drop(op.get_bind())
+    supported_arch.drop(op.get_bind())

--- a/apollo/handlers/agent.py
+++ b/apollo/handlers/agent.py
@@ -15,7 +15,7 @@ from apollo.lib.websocket.app import (
     AppConnectionManager, WebSocketObserverInterestType)
 from apollo.lib.websocket.user import UserConnectionManager
 from apollo.models import get_session, save
-from apollo.models.agent import Agent, list_all_agents
+from apollo.models.agent import Agent, list_all_agents, get_agent_by_id
 from apollo.models.oauth import OAuthClient
 
 router = SecureRouter([
@@ -32,11 +32,11 @@ router = SecureRouter([
     observer_interest_type=WebSocketObserverInterestType.AGENT_LISTING)
 def post_agent(agent_data: CreateAgentSchema,
                session: Session = Depends(get_session)):
-    agent, _ = save(session, Agent(
+    _, id_ = save(session, Agent(
         oauth_client=OAuthClient(type='confidential'),
         **dict(agent_data)
     ))
-    return agent
+    return get_agent_by_id(session, id_)
 
 
 @router.get('/agent', status_code=200, response_model=List[BaseAgentSchema],

--- a/apollo/handlers/websocket.py
+++ b/apollo/handlers/websocket.py
@@ -27,7 +27,6 @@ async def connect(
         _update_agent_machine_info(websocket, session, agent_id)
     except (ValueError, ValidationError) as e:
         logging.error("Unable to set machine info", exc_info=e)
-        pass
 
     await AgentConnectionManager().connect(agent_id, websocket)
 

--- a/apollo/handlers/websocket.py
+++ b/apollo/handlers/websocket.py
@@ -1,3 +1,6 @@
+import logging
+import uuid
+
 from fastapi import WebSocket, Depends
 from sqlalchemy.orm import Session
 
@@ -5,7 +8,8 @@ from apollo.lib.router import SecureRouter
 from apollo.lib.security import (
     Allow, Agent, get_client_id_from_authorization_header)
 from apollo.lib.websocket.agent import AgentConnectionManager
-from apollo.models import get_session
+from apollo.models import get_session, save
+from apollo.models.agent import get_agent_by_id
 
 router = SecureRouter([(Allow, Agent, 'connect')])
 
@@ -17,4 +21,14 @@ async def connect(
 ):
     agent_id = get_client_id_from_authorization_header(
         session=session, authorization=websocket.headers['authorization'])
+    update_agent_machine_info(websocket, session, agent_id)
     await AgentConnectionManager().connect(agent_id, websocket)
+
+def update_agent_machine_info(
+    websocket: WebSocket,
+    session: Session,
+    agent_id: uuid.UUID
+):
+    agent = get_agent_by_id(session, agent_id)
+    agent.external_ip_address = websocket.client.host
+    # save(session, agent)

--- a/apollo/lib/schemas/agent.py
+++ b/apollo/lib/schemas/agent.py
@@ -1,5 +1,6 @@
 import uuid
 
+from ipaddress import IPv4Address
 from pydantic import BaseModel, constr, validator
 from starlette.websockets import WebSocketState
 
@@ -27,6 +28,8 @@ class BaseAgentSchema(ORMBase):
     id: uuid.UUID
     name: str
     connection_state: WebSocketState = WebSocketState.DISCONNECTED
+    external_ip_address: IPv4Address
+    operating_system: str
 
     @validator('connection_state')
     @classmethod

--- a/apollo/lib/schemas/agent.py
+++ b/apollo/lib/schemas/agent.py
@@ -3,6 +3,7 @@ import uuid
 from ipaddress import IPv4Address
 from pydantic import BaseModel, constr, validator
 from starlette.websockets import WebSocketState
+from typing import Optional
 
 from apollo.lib.agent import SupportedArch, SupportedOS
 from apollo.lib.decorators import with_db_session
@@ -25,16 +26,19 @@ class CreateAgentSchema(BaseModel):
         raise ValueError("An agent with the given name already exists")
 
 
-class AgentPlatformSchema(BaseModel):
+class CreateAgentPlatformSchema(ORMBase):
     external_ip_address: IPv4Address
     operating_system: SupportedOS
     architecture: SupportedArch
 
 
-class BaseAgentSchema(ORMBase, AgentPlatformSchema):
+class BaseAgentSchema(ORMBase):
     id: uuid.UUID
     name: str
     connection_state: WebSocketState = WebSocketState.DISCONNECTED
+    external_ip_address: Optional[IPv4Address]
+    operating_system: Optional[SupportedOS]
+    architecture: Optional[SupportedArch]
 
     @validator('connection_state')
     @classmethod

--- a/apollo/lib/schemas/agent.py
+++ b/apollo/lib/schemas/agent.py
@@ -4,6 +4,7 @@ from ipaddress import IPv4Address
 from pydantic import BaseModel, constr, validator
 from starlette.websockets import WebSocketState
 
+from apollo.lib.agent import SupportedArch, SupportedOS
 from apollo.lib.decorators import with_db_session
 from apollo.lib.schemas import ORMBase
 from apollo.lib.schemas.oauth import OAuthClientSchema
@@ -29,7 +30,8 @@ class BaseAgentSchema(ORMBase):
     name: str
     connection_state: WebSocketState = WebSocketState.DISCONNECTED
     external_ip_address: IPv4Address
-    operating_system: str
+    operating_system: SupportedOS
+    architecture: SupportedArch
 
     @validator('connection_state')
     @classmethod

--- a/apollo/lib/schemas/agent.py
+++ b/apollo/lib/schemas/agent.py
@@ -25,13 +25,16 @@ class CreateAgentSchema(BaseModel):
         raise ValueError("An agent with the given name already exists")
 
 
-class BaseAgentSchema(ORMBase):
-    id: uuid.UUID
-    name: str
-    connection_state: WebSocketState = WebSocketState.DISCONNECTED
+class AgentPlatformSchema(BaseModel):
     external_ip_address: IPv4Address
     operating_system: SupportedOS
     architecture: SupportedArch
+
+
+class BaseAgentSchema(ORMBase, AgentPlatformSchema):
+    id: uuid.UUID
+    name: str
+    connection_state: WebSocketState = WebSocketState.DISCONNECTED
 
     @validator('connection_state')
     @classmethod

--- a/apollo/models/agent.py
+++ b/apollo/models/agent.py
@@ -14,6 +14,8 @@ class Agent(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(100), unique=True, nullable=False)
+    #external_ip_address = Column(String(16), nullable=True)
+    #operating_system = Column(String(100), nullable=True)
 
     oauth_client = relationship('OAuthClient', uselist=False,
                                 cascade="all, delete-orphan")
@@ -30,6 +32,10 @@ class Agent(Base):
 
 def get_agent_by_name(session, name):
     return session.query(Agent).filter(Agent.name == name).one_or_none()
+
+
+def get_agent_by_id(session, id_):
+    return session.query(Agent).get(id_)
 
 
 def list_all_agents(session):

--- a/apollo/models/agent.py
+++ b/apollo/models/agent.py
@@ -16,8 +16,10 @@ class Agent(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(100), unique=True, nullable=False)
     external_ip_address = Column(String(16), nullable=True)
-    operating_system = Column(Enum(SupportedOS), nullable=True)
-    architecture = Column(Enum(SupportedArch), nullable=True)
+    operating_system = Column(Enum(*[member.value for member in SupportedOS]),
+                              nullable=True)
+    architecture = Column(Enum(*[member.value for member in SupportedArch]),
+                          nullable=True)
 
     oauth_client = relationship('OAuthClient', uselist=False,
                                 cascade="all, delete-orphan")

--- a/apollo/models/agent.py
+++ b/apollo/models/agent.py
@@ -1,10 +1,11 @@
 import uuid
 
-from sqlalchemy import Column, String
+from sqlalchemy import Column, Enum, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from starlette.websockets import WebSocketState
 
+from apollo.lib.agent import SupportedArch, SupportedOS
 from apollo.lib.websocket.agent import AgentConnectionManager
 from apollo.models import Base
 
@@ -14,8 +15,9 @@ class Agent(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(100), unique=True, nullable=False)
-    #external_ip_address = Column(String(16), nullable=True)
-    #operating_system = Column(String(100), nullable=True)
+    external_ip_address = Column(String(16), nullable=True)
+    operating_system = Column(Enum(SupportedOS), nullable=True)
+    architecture = Column(Enum(SupportedArch), nullable=True)
 
     oauth_client = relationship('OAuthClient', uselist=False,
                                 cascade="all, delete-orphan")

--- a/tests/handlers/test_agent.py
+++ b/tests/handlers/test_agent.py
@@ -9,7 +9,7 @@ from apollo.lib.schemas.message import (Command, CommandSchema,
                                         ShellIOSchema)
 from apollo.lib.websocket.agent import AgentConnection
 from apollo.lib.websocket.interest_type import WebSocketObserverInterestType
-from apollo.models.agent import Agent
+from apollo.models.agent import Agent, get_agent_by_id
 from apollo.models.oauth import OAuthClient
 from tests.lib.websocket import assert_interested_connections_messaged
 
@@ -18,7 +18,8 @@ from tests.lib.websocket import assert_interested_connections_messaged
 @assert_interested_connections_messaged(
     WebSocketObserverInterestType.AGENT_LISTING
 )
-async def test_post_agent_success(async_test_client, session_cookie):
+async def test_post_agent_success(async_test_client, session_cookie,
+                                  db_session):
     response = await async_test_client.post(
         '/agent',
         json={'name': 'test'},
@@ -32,6 +33,11 @@ async def test_post_agent_success(async_test_client, session_cookie):
     assert oauth_client['agent_id'] is not None
     assert oauth_client['secret'] is not None
     assert oauth_client['type'] == 'confidential'
+
+    persisted_agent = get_agent_by_id(db_session, agent['id'])
+    assert persisted_agent.external_ip_address is None
+    assert persisted_agent.operating_system is None
+    assert persisted_agent.architecture is None
 
 
 def test_post_agent_name_exists(test_client, session_cookie):

--- a/tests/handlers/test_agent.py
+++ b/tests/handlers/test_agent.py
@@ -146,15 +146,32 @@ def assert_list_agent_response_data(data, agent_id_1, agent_id_2):
     assert agent_data['name'] in ['test', 'test2']
     assert agent_data['id'] in [str(agent_id_1), str(agent_id_2)]
     assert agent_data['connection_state'] == 'disconnected'
+    assert agent_data['external_ip_address'] == '0.0.0.0'
+    assert agent_data['operating_system'] == 'darwin'
+    assert agent_data['architecture'] == 'amd64'
 
 
 def add_multiple_agents(db_session):
     agent_id_1 = uuid.uuid4()
     agent_id_2 = uuid.uuid4()
-    agent = Agent(id=agent_id_1, name='test',
-                  oauth_client=OAuthClient(type='confidential'))
-    agent_2 = Agent(id=agent_id_2, name='test2',
-                    oauth_client=OAuthClient(type='confidential'))
+    platform_info = {
+        'external_ip_address': '0.0.0.0',
+        'operating_system': 'darwin',
+        'architecture': 'amd64'
+    }
+
+    agent = Agent(
+        id=agent_id_1,
+        name='test',
+        oauth_client=OAuthClient(type='confidential'),
+        **platform_info
+    )
+    agent_2 = Agent(
+        id=agent_id_2,
+        name='test2',
+        oauth_client=OAuthClient(type='confidential'),
+        **platform_info
+    )
     db_session.add(agent)
     db_session.add(agent_2)
     db_session.commit()

--- a/tests/handlers/test_websocket.py
+++ b/tests/handlers/test_websocket.py
@@ -1,14 +1,56 @@
+from unittest.mock import patch
+
 import pytest
 
+from apollo.models.agent import get_agent_by_id
 from tests.asserts import raisesHTTPForbidden
 
 
 @pytest.mark.asyncio
-async def test_connect(test_client, authenticated_agent_headers):
-    with test_client.websocket_connect(
-        '/ws', headers=authenticated_agent_headers
-    ) as websocket:
-        websocket.close(code=1000)
+async def test_connect(test_client, authenticated_agent_headers, db_session,
+                       access_token):
+    headers = {
+        'user-agent': "Apollo Agent - darwin/amd64",
+        **authenticated_agent_headers
+    }
+
+    with patch('fastapi.WebSocket.client') as client_mock:
+        client_mock.host = '0.0.0.0'
+        with test_client.websocket_connect(
+            '/ws', headers=headers,
+        ) as websocket:
+            websocket.close(code=1000)
+
+    agent = get_agent_by_id(db_session, access_token.client_id)
+    assert agent.operating_system == 'darwin'
+    assert agent.architecture == 'amd64'
+
+
+@pytest.mark.asyncio
+async def test_connect_invalid_user_agent(
+    test_client,
+    authenticated_agent_headers,
+    db_session,
+    access_token
+):
+    headers = {
+        'user-agent': "fake",
+        **authenticated_agent_headers
+    }
+
+    with patch('apollo.handlers.websocket.logging.error') as log_mock:
+        with patch('fastapi.WebSocket.client') as client_mock:
+            client_mock.host = '0.0.0.0'
+            with test_client.websocket_connect(
+                '/ws', headers=headers,
+            ) as websocket:
+                websocket.close(code=1000)
+
+        log_mock.assert_called_once()
+
+    agent = get_agent_by_id(db_session, access_token.client_id)
+    assert agent.operating_system is None
+    assert agent.architecture is None
 
 
 def test_connect_unauthenticated(test_client):

--- a/tests/lib/websocket/test_interest_type.py
+++ b/tests/lib/websocket/test_interest_type.py
@@ -8,7 +8,10 @@ from apollo.models.agent import Agent
 
 def test_interest_type_function_handler_run_agent_listing_function(db_session):
     agent_id = uuid.uuid4()
-    agent = Agent(id=agent_id, name='test')
+    agent = Agent(
+        id=agent_id,
+        name='test'
+    )
     db_session.add(agent)
     db_session.commit()
 
@@ -19,7 +22,10 @@ def test_interest_type_function_handler_run_agent_listing_function(db_session):
     assert data[0] == {
         'id': agent_id,
         'name': 'test',
-        'connection_state': 'disconnected'
+        'connection_state': 'disconnected',
+        'external_ip_address': None,
+        'operating_system': None,
+        'architecture': None
     }
 
 

--- a/tests/models/test_agent.py
+++ b/tests/models/test_agent.py
@@ -1,8 +1,11 @@
+import uuid
+
 import pytest
 from starlette.websockets import WebSocketState
 
 from apollo.lib.websocket.agent import AgentConnection
-from apollo.models.agent import Agent, get_agent_by_name, list_all_agents
+from apollo.models.agent import (Agent, get_agent_by_name, list_all_agents,
+                                 get_agent_by_id)
 from apollo.models.oauth import OAuthClient
 
 
@@ -42,6 +45,25 @@ def test_get_agent_by_name_not_found(db_session):
     db_session.commit()
 
     assert get_agent_by_name(db_session, 'different') is None
+
+
+def test_get_agent_by_id(db_session):
+    agent = Agent(name='test')
+    db_session.add(agent)
+    db_session.flush()
+    agent_id = agent.id
+    db_session.commit()
+
+    persisted_agent = get_agent_by_id(db_session, agent_id)
+    assert persisted_agent.id == agent_id
+
+
+def test_get_agent_by_id_not_found(db_session):
+    agent = Agent(name='test')
+    db_session.add(agent)
+    db_session.commit()
+
+    assert get_agent_by_id(db_session, uuid.uuid4()) is None
 
 
 def test_list_all_agents_size(db_session):


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-59>

## Description
Collets the OS and architecture from the agent websocket `user-agent` header. This info is returned together with the agent's external IP address when listing agents.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

* https://github.com/thecoderstudio/apollo-agent/pull/14

## Additional notes

