### PR TITLE
AP-61 login timeout

### DIFF
--- a/apollo/handlers/auth.py
+++ b/apollo/handlers/auth.py
@@ -30,6 +30,7 @@ def login(response: Response, login_data: LoginSchema,
 
     user = get_user_by_username(session, login_data.username)
     shield.raise_if_locked(resource="account")
+    shield.increment_attempts()
 
     if user:
         password_hash, password_salt = user.password_hash, user.password_salt
@@ -40,7 +41,6 @@ def login(response: Response, login_data: LoginSchema,
 
     if not compare_plaintext_to_hash(login_data.password, password_hash,
                                      password_salt):
-        shield.increment_attempts()
         raise HTTPException(status_code=400,
                             detail="Username and/or password is incorrect")
 

--- a/apollo/handlers/auth.py
+++ b/apollo/handlers/auth.py
@@ -22,7 +22,6 @@ def login(response: Response, login_data: LoginSchema,
           session: Session = Depends(get_session)):
     security_settings = settings['security']
     shield = RequestShield(
-        'account',
         login_data.username,
         int(security_settings['max_login_attempts']),
         int(security_settings['login_lockout_interval_in_seconds']),
@@ -30,7 +29,7 @@ def login(response: Response, login_data: LoginSchema,
     )
 
     user = get_user_by_username(session, login_data.username)
-    shield.raise_if_locked()
+    shield.raise_if_locked(resource="account")
 
     if user:
         password_hash, password_salt = user.password_hash, user.password_salt

--- a/apollo/handlers/auth.py
+++ b/apollo/handlers/auth.py
@@ -2,6 +2,7 @@ from fastapi import Depends, HTTPException, Response
 from sqlalchemy.orm import Session
 
 from apollo.lib.hash import compare_plaintext_to_hash
+from apollo.lib.redis import RedisSession
 from apollo.lib.router import SecureRouter
 from apollo.lib.schemas.auth import LoginSchema
 from apollo.lib.security import Allow, Everyone, create_session_cookie
@@ -18,6 +19,18 @@ FAKE_PASSWORD_SALT = "$2b$12$TEfhqmu/6mXaYqMZUkTAZu"
 @router.post("/auth/login", status_code=200, permission='login')
 def login(response: Response, login_data: LoginSchema,
           session: Session = Depends(get_session)):
+    redis_session = RedisSession()
+    attempt_key = f"login_attempt:{login_data.username}"
+    locked_key = f"locked:{login_data.username}"
+
+    if redis_session.get_from_cache(locked_key, 0):
+        locked_time = redis_session.get_ttl(locked_key)
+        raise HTTPException(
+            status_code=400,
+            detail="This account is locked, "
+            f"try again in {locked_time} seconds"
+        )
+
     user = get_user_by_username(session, login_data.username)
 
     if user:
@@ -29,7 +42,19 @@ def login(response: Response, login_data: LoginSchema,
 
     if not compare_plaintext_to_hash(login_data.password, password_hash,
                                      password_salt):
+        login_attempt = int(redis_session.get_from_cache(attempt_key, 0))
+        login_attempt += 1
+        redis_session.write_to_cache(attempt_key, login_attempt)
+
+        if login_attempt >= 3:
+            redis_session.write_to_cache(
+                locked_key,
+                1,
+                min(300 * login_attempt, 10800)
+            )
+
         raise HTTPException(status_code=400,
                             detail="Username and/or password is incorrect")
 
+    redis_session.delete(attempt_key)
     response.set_cookie(*create_session_cookie(user))

--- a/apollo/lib/redis.py
+++ b/apollo/lib/redis.py
@@ -29,7 +29,11 @@ class RedisSession(object, metaclass=Singleton):
         return result.decode('utf-8')
 
     def get_ttl(self, key):
-        return self.session.ttl(key)
+        ttl = self.session.ttl(key)
+        if ttl < 0:
+            return None
+
+        return ttl
 
     def delete(self, key):
         self.session.delete(key)

--- a/apollo/lib/redis.py
+++ b/apollo/lib/redis.py
@@ -30,3 +30,6 @@ class RedisSession(object, metaclass=Singleton):
 
     def get_ttl(self, key):
         return self.session.ttl(key)
+
+    def delete(self, key):
+        self.session.delete(key)

--- a/apollo/lib/redis.py
+++ b/apollo/lib/redis.py
@@ -22,5 +22,11 @@ class RedisSession(object, metaclass=Singleton):
     def get_dict_from_cache(self, key):
         return self.session.hgetall(key)
 
-    def get_from_cache(self, key):
-        return self.session.get(key)
+    def get_from_cache(self, key, default=None):
+        result = self.session.get(key)
+        if result is None:
+            return default
+        return result.decode('utf-8')
+
+    def get_ttl(self, key):
+        return self.session.ttl(key)

--- a/apollo/lib/security/shield.py
+++ b/apollo/lib/security/shield.py
@@ -46,7 +46,7 @@ class RequestShield:
         attempt += 1
         self.redis_session.write_to_cache(self.attempt_key, attempt)
 
-        if attempt > self.max_attempts:
+        if attempt >= self.max_attempts:
             self.redis_session.write_to_cache(self.locked_key, int(True), min(
                 self.lockout_interval * attempt,
                 self.max_lockout_time

--- a/apollo/lib/security/shield.py
+++ b/apollo/lib/security/shield.py
@@ -47,7 +47,7 @@ class RequestShield:
         self.redis_session.write_to_cache(self.attempt_key, attempt)
 
         if attempt > self.max_attempts:
-            self.redis_session.write_to_cache(self.locked_key, 1, min(
+            self.redis_session.write_to_cache(self.locked_key, int(True), min(
                 self.lockout_interval * attempt,
                 self.max_lockout_time
             ))

--- a/apollo/lib/security/shield.py
+++ b/apollo/lib/security/shield.py
@@ -1,0 +1,49 @@
+from fastapi import HTTPException
+
+from apollo.lib.redis import RedisSession
+
+
+class RequestShield:
+    def __init__(self, resource, max_attempts, lockout_interval,
+                 max_lockout_time):
+        self.resource = resource
+        self.max_attempts = max_attempts
+        self.lockout_interval = lockout_interval
+        self.max_lockout_time = max_lockout_time
+        self.redis_session = RedisSession()
+
+    def lock_if_required(self, key):
+        locked_key = self._get_locked_key(key)
+        if self.redis_session.get_from_cache(locked_key, 0):
+            locked_time = self.redis_session.get_ttl(locked_key)
+            raise HTTPException(
+                status_code=400,
+                detail="This account is locked, "
+                f"try again in {locked_time} seconds"
+            )
+
+    def increment_attempts(self, key):
+        attempt_key = self._get_attempt_key(key)
+        locked_key = self._get_locked_key(key)
+
+        attempt = int(self.redis_session.get_from_cache(attempt_key, 0))
+        attempt += 1
+        self.redis_session.write_to_cache(attempt_key, attempt)
+
+        if attempt >= self.max_attempts:
+            self.redis_session.write_to_cache(locked_key, 1, min(
+                self.lockout_interval * attempt,
+                self.max_lockout_time
+            ))
+
+    def clear(self, key):
+        self.redis_session.delete(self._get_attempt_key(key))
+        self.redis_session.delete(self._get_locked_key(key))
+
+    @staticmethod
+    def _get_attempt_key(key):
+        return f"attempt:{key}"
+
+    @staticmethod
+    def _get_locked_key(key):
+        return f"locked:{key}"

--- a/settings.ini
+++ b/settings.ini
@@ -10,7 +10,7 @@ default_ttl_in_seconds = 3600
 
 [security]
 max_login_lockout_in_seconds = 10800
-login_lockout_interval_in_seconds = 300
+login_lockout_interval_in_seconds = 150
 max_login_attempts = 3
 
 

--- a/settings.ini
+++ b/settings.ini
@@ -8,6 +8,12 @@ port = 6379
 db = 0
 default_ttl_in_seconds = 3600
 
+[security]
+max_login_lockout_in_seconds = 10800
+login_lockout_interval_in_seconds = 300
+max_login_attempts = 3
+
+
 [Web]
 domain = localhost
 port = 1971

--- a/settings.ini
+++ b/settings.ini
@@ -10,7 +10,7 @@ default_ttl_in_seconds = 3600
 
 [security]
 max_login_lockout_in_seconds = 10800
-login_lockout_interval_in_seconds = 150
+login_lockout_interval_in_seconds = 200 
 max_login_attempts = 3
 
 

--- a/test.ini
+++ b/test.ini
@@ -9,7 +9,7 @@ password = testing123
 host = redis-test
 port = 6379
 db = 0
-default_ttl_in_seconds = 1
+default_ttl_in_seconds = 3600
 
 [security]
 max_login_lockout_in_seconds = 10800

--- a/test.ini
+++ b/test.ini
@@ -13,7 +13,7 @@ default_ttl_in_seconds = 3600
 
 [security]
 max_login_lockout_in_seconds = 10800
-login_lockout_interval_in_seconds = 150
+login_lockout_interval_in_seconds = 200 
 max_login_attempts = 3
 
 [session]

--- a/test.ini
+++ b/test.ini
@@ -13,7 +13,7 @@ default_ttl_in_seconds = 3600
 
 [security]
 max_login_lockout_in_seconds = 10800
-login_lockout_interval_in_seconds = 300
+login_lockout_interval_in_seconds = 150
 max_login_attempts = 3
 
 [session]

--- a/test.ini
+++ b/test.ini
@@ -11,6 +11,11 @@ port = 6379
 db = 0
 default_ttl_in_seconds = 1
 
+[security]
+max_login_lockout_in_seconds = 10800
+login_lockout_interval_in_seconds = 300
+max_login_attempts = 3
+
 [session]
 # Don't reuse, only for test
 secret = 03aa24c04d80ee5e4e17bf62db461e3b2b5777091c7f28072947f8b81e7a2958 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def empty_tables():
         trans.commit()
 
 
-@fixture
+@fixture(autouse=True)
 def redis_session(patched_settings):
     try:
         config = ConfigParser()

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -36,7 +36,6 @@ def test_locked_after_too_many_attempts(test_client, db_session):
     test_client.post('/auth/login', json=credentials)
     test_client.post('/auth/login', json=credentials)
     test_client.post('/auth/login', json=credentials)
-    test_client.post('/auth/login', json=credentials)
     response = test_client.post('/auth/login', json=credentials)
 
     assert response.status_code == 400

--- a/tests/handlers/test_auth.py
+++ b/tests/handlers/test_auth.py
@@ -30,6 +30,20 @@ def test_login_wrong_credentials(test_client, db_session, username, password):
     assert response.json()['detail'] == "Username and/or password is incorrect"
 
 
+def test_locked_after_too_many_attempts(test_client, db_session):
+    create_test_user(db_session)
+    credentials = {'username': 'testuser', 'password': 'fake123'}
+    test_client.post('/auth/login', json=credentials)
+    test_client.post('/auth/login', json=credentials)
+    test_client.post('/auth/login', json=credentials)
+    test_client.post('/auth/login', json=credentials)
+    response = test_client.post('/auth/login', json=credentials)
+
+    assert response.status_code == 400
+    assert response.json()['detail'] == (
+        "This account is locked, try again in 600 seconds")
+
+
 def create_test_user(db_session):
     username = 'testuser'
     password = 'testing123'

--- a/tests/lib/security/test_shield.py
+++ b/tests/lib/security/test_shield.py
@@ -24,7 +24,7 @@ def test_validate_initial_arguments():
 
 
 def test_lock_on_too_many_attempts():
-    shield = RequestShield('test', 2, 5, 15)
+    shield = RequestShield('test', 3, 5, 15)
 
     shield.increment_attempts()
     assert shield.attempts == 1
@@ -41,7 +41,7 @@ def test_lock_on_too_many_attempts():
 
 
 def test_no_reattempt_when_locked():
-    shield = RequestShield('test', 0, 10, 15)
+    shield = RequestShield('test', 1, 10, 15)
     shield.increment_attempts()
 
     with pytest.raises(ValueError, match="Can't reattempt when locked"):
@@ -49,7 +49,7 @@ def test_no_reattempt_when_locked():
 
 
 def test_raise_when_locked():
-    shield = RequestShield('test', 0, 5, 15)
+    shield = RequestShield('test', 1, 5, 15)
     shield.increment_attempts()
 
     with pytest.raises(HTTPException):
@@ -57,12 +57,12 @@ def test_raise_when_locked():
 
 
 def test_no_raise_when_not_locked():
-    shield = RequestShield('test', 0, 5, 15)
+    shield = RequestShield('test', 1, 5, 15)
     shield.raise_if_locked()
 
 
 def test_locktime_increases_with_every_failed_attempt():
-    shield = RequestShield('test', 0, 1, 15)
+    shield = RequestShield('test', 1, 1, 15)
     shield.increment_attempts()
 
     time.sleep(2)
@@ -73,14 +73,14 @@ def test_locktime_increases_with_every_failed_attempt():
 
 
 def test_locktime_does_not_exceed_maximum():
-    shield = RequestShield('test', 0, 10, 5)
+    shield = RequestShield('test', 1, 10, 5)
     shield.increment_attempts()
 
     assert shield.time_locked_in_seconds == 5
 
 
 def test_clear():
-    shield = RequestShield('test', 0, 10, 5)
+    shield = RequestShield('test', 1, 10, 5)
     shield.increment_attempts()
 
     shield.clear()

--- a/tests/lib/security/test_shield.py
+++ b/tests/lib/security/test_shield.py
@@ -52,9 +52,8 @@ def test_raise_when_locked():
     shield = RequestShield('test', 0, 5, 15)
     shield.increment_attempts()
 
-    with pytest.raises(HTTPException) as e:
+    with pytest.raises(HTTPException):
         shield.raise_if_locked()
-        print(str(e))
 
 
 def test_no_raise_when_not_locked():

--- a/tests/lib/security/test_shield.py
+++ b/tests/lib/security/test_shield.py
@@ -1,0 +1,72 @@
+import time
+
+import pytest
+from fastapi import HTTPException
+
+from apollo.lib.security.shield import RequestShield
+
+
+def test_lock_on_too_many_attempts():
+    shield = RequestShield('test', 3, 5, 15)
+
+    shield.increment_attempts()
+    assert shield.attempts == 1
+    assert shield.locked is False
+
+    shield.increment_attempts()
+    assert shield.attempts == 2
+    assert shield.locked is False
+
+    shield.increment_attempts()
+    assert shield.attempts == 3
+    assert shield.locked is True
+    assert shield.time_locked_in_seconds == 15
+
+
+def test_no_reattempt_when_locked():
+    shield = RequestShield('test', 1, 10, 15)
+    shield.increment_attempts()
+
+    with pytest.raises(ValueError, match="Can't reattempt when locked"):
+        shield.increment_attempts()
+
+
+def test_raise_when_locked():
+    shield = RequestShield('test', 1, 5, 15)
+    shield.increment_attempts()
+
+    with pytest.raises(HTTPException) as e:
+        shield.raise_if_locked()
+        print(str(e))
+
+
+def test_no_raise_when_not_locked():
+    shield = RequestShield('test', 1, 5, 15)
+    shield.raise_if_locked()
+
+
+def test_locktime_increases_with_every_failed_attempt():
+    shield = RequestShield('test', 1, 1, 15)
+    shield.increment_attempts()
+
+    time.sleep(2)
+
+    shield.increment_attempts()
+
+    assert shield.time_locked_in_seconds == 2
+
+
+def test_locktime_does_not_exceed_maximum():
+    shield = RequestShield('test', 1, 10, 5)
+    shield.increment_attempts()
+
+    assert shield.time_locked_in_seconds == 5
+
+
+def test_clear():
+    shield = RequestShield('test', 1, 10, 5)
+    shield.increment_attempts()
+
+    shield.clear()
+    assert shield.attempts == 0
+    assert shield.locked is False

--- a/tests/lib/test_redis.py
+++ b/tests/lib/test_redis.py
@@ -47,10 +47,14 @@ def test_get_dict_from_cache(redis_session):
 
 
 def test_get_from_cache(redis_session):
-    data = b'a'
+    data = 'a'
     redis_session.write_to_cache('test', data)
 
     assert redis_session.get_from_cache('test') == data
+
+
+def test_get_from_cache_not_found(redis_session):
+    assert redis_session.get_from_cache('fake', 'test') == 'test'
 
 
 def get_strict_redis():

--- a/tests/lib/test_redis.py
+++ b/tests/lib/test_redis.py
@@ -57,6 +57,25 @@ def test_get_from_cache_not_found(redis_session):
     assert redis_session.get_from_cache('fake', 'test') == 'test'
 
 
+def test_get_ttl(redis_session):
+    redis_session.write_to_cache('test', 'a', 10)
+    assert redis_session.get_ttl('test') == 10
+
+
+def test_get_ttl_not_found(redis_session):
+    redis_session.get_ttl('test') is None
+
+
+def test_delete(redis_session):
+    redis_session.write_to_cache('test', 'a')
+    redis_session.delete('test')
+    assert redis_session.get_from_cache('test') is None
+
+
+def test_delete_not_found(redis_session):
+    redis_session.delete('test')
+
+
 def get_strict_redis():
     redis_settings, lifetime = get_redis_settings()
 

--- a/tests/lib/test_redis.py
+++ b/tests/lib/test_redis.py
@@ -63,7 +63,7 @@ def test_get_ttl(redis_session):
 
 
 def test_get_ttl_not_found(redis_session):
-    redis_session.get_ttl('test') is None
+    assert redis_session.get_ttl('test') is None
 
 
 def test_delete(redis_session):


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-61>

## Description
Adds a `RequestShield` class that's used in the login handler to lockout requests after 3 failed attempts. Failed attempts afterwards will then increase the lockout time. A successful attempt resets the state for the user.

![image](https://user-images.githubusercontent.com/5303534/93463642-51ff2c00-f8e8-11ea-9dea-a1715c0accae.png)


## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

* https://github.com/thecoderstudio/apollo/pull/34

## Additional notes
Nope