### PR TITLE
hotfix: use new package and set reload time

### DIFF
--- a/dev-compose.yml
+++ b/dev-compose.yml
@@ -21,7 +21,7 @@ services:
     command: >
       -c "../util/wait-for-it.sh db:5432 &&
       alembic -c local-settings.ini upgrade heads &&
-      uvicorn apollo:main --log-config local-settings.ini --reload --host 0.0.0.0"
+      uvicorn apollo:main --log-config local-settings.ini --reload --reload-delay 1 --host 0.0.0.0"
   db:
     container_name: apollo-db
     image: postgres:12

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requires = [
     'pyjwt',
     'redis',
     'sqlalchemy',
-    'uvicorn[watchgodreload]'
+    'uvicorn[standard]'
 ]
 
 test_requires = [


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP->

## Description
* `watchgod` is now included in the `standard` package as specified [here](https://github.com/encode/uvicorn/pull/666) which is why the build currently breaks.
* With the new Uvicorn release a configurable reload delay has also been introduced as specified [here](https://github.com/encode/uvicorn/pull/774/files). I've set this to 1s which may help against the high CPU load we're seeing from the hot reload function. 

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

*

## Additional notes
Nope